### PR TITLE
feat(matching): employer match bands + Karirhub mock + verified badge + benchmark

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -28,6 +28,7 @@ from backend.app.api.routers.agent import router as agent_router
 from backend.app.api.routers.auth import router as auth_router
 from backend.app.api.routers.employer import router as employer_router  # prefix=/employer
 from backend.app.api.routers.jobs import router as jobs_router
+from backend.app.api.routers.karirhub import router as karirhub_router
 from backend.app.api.routers.seeker import router as seeker_router
 from backend.app.api.routers.uploads import router as uploads_router
 from backend.app.api.routers.verify import router as verify_router
@@ -76,7 +77,7 @@ app.add_middleware(
 )
 
 for r in (auth_router, seeker_router, employer_router, jobs_router,
-          uploads_router, verify_router, agent_router):
+          uploads_router, verify_router, agent_router, karirhub_router):
     app.include_router(r, prefix="/api/v1")
 
 

--- a/backend/app/api/routers/employer.py
+++ b/backend/app/api/routers/employer.py
@@ -245,7 +245,7 @@ async def find_candidates(
     if not job:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Lowongan tidak ditemukan")
 
-    top_k = int((body or {}).get("top_k", 10))
+    top_k = int((body or {}).get("top_k", 15))
     filters = (body or {}).get("filters", {})
     seekers = await repos.seekers.list()
     if not seekers:

--- a/backend/app/api/routers/jobs.py
+++ b/backend/app/api/routers/jobs.py
@@ -2,9 +2,15 @@
 from __future__ import annotations
 
 from backend.app.db.postgres_store import get_repositories
+from backend.app.db.schemas import Employer, VerificationStatus
 from fastapi import APIRouter
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
+
+
+def _is_verified(employer: Employer | None) -> bool:
+    """A listing is trusted when its posting employer passed verification."""
+    return employer is not None and employer.verified == VerificationStatus.VERIFIED
 
 
 @router.get("")
@@ -34,11 +40,19 @@ async def list_jobs(
             if q_lower in j.title.lower() or q_lower in j.description.lower()
         ]
     total = len(jobs)
-    return {"total": total, "offset": offset, "limit": limit, "items": jobs[offset: offset + limit]}
+    page = jobs[offset: offset + limit]
+    items = []
+    for j in page:
+        employer = await repos.employers.get(j.employer_id)
+        items.append(j.model_dump() | {"verified": _is_verified(employer)})
+    return {"total": total, "offset": offset, "limit": limit, "items": items}
 
 
 @router.get("/{job_id}")
 async def get_job(job_id: str):
     repos = get_repositories()
     j = await repos.jobs.get(job_id)
-    return j or {"error": "not_found"}
+    if not j:
+        return {"error": "not_found"}
+    employer = await repos.employers.get(j.employer_id)
+    return j.model_dump() | {"verified": _is_verified(employer)}

--- a/backend/app/api/routers/karirhub.py
+++ b/backend/app/api/routers/karirhub.py
@@ -1,0 +1,40 @@
+"""Karirhub (national job system) sync endpoints — backed by a MOCK connector.
+
+Endpoints (registered under /api/v1):
+  POST /karirhub/sync      feed active vacancies to the national system (mock)
+  GET  /karirhub/listings  pull verified national listings (mock)
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+
+from backend.app.db.postgres_store import get_repositories
+from backend.app.services.integrations.karirhub import (
+    pull_verified_listings,
+    push_vacancies,
+)
+
+router = APIRouter(prefix="/karirhub", tags=["karirhub"])
+
+
+@router.post("/sync")
+async def sync_vacancies() -> dict[str, Any]:
+    """Feed active vacancies to the national system (mock).
+
+    Tolerates an empty/unavailable store by defaulting to no jobs.
+    """
+    try:
+        repos = get_repositories()
+        jobs = await repos.jobs.list()
+    except Exception:  # noqa: BLE001 - store is optional for this mock
+        jobs = []
+    return push_vacancies(jobs)
+
+
+@router.get("/listings")
+async def list_verified_listings(region: str | None = None) -> dict[str, Any]:
+    """Pull verified national listings (mock), optionally filtered by region."""
+    items = pull_verified_listings(region)
+    return {"total": len(items), "items": items}

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -69,6 +69,11 @@ class Settings(BaseSettings):
     matching_region_weight: float = 0.10
     matching_salary_weight: float = 0.05
     matching_experience_weight: float = 0.05
+    # Band thresholds for the recruiter shortlist (employer-side). Tunable so
+    # they can be calibrated against the real score distribution
+    # (see backend/scripts/benchmark_matching.py). Scores are in [0..1].
+    band_strong_threshold: float = 0.65
+    band_possible_threshold: float = 0.45
 
     # ── Agent temperatures ───────────────────────────────────────────────
     advisor_temperature: float = 0.7

--- a/backend/app/services/integrations/__init__.py
+++ b/backend/app/services/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""External-system integrations (mocked for the MVP)."""

--- a/backend/app/services/integrations/karirhub.py
+++ b/backend/app/services/integrations/karirhub.py
@@ -1,0 +1,82 @@
+"""MOCK Karirhub / SIAPkerja connector.
+
+This module SIMULATES integration with Karirhub (the Indonesian national job
+system run by Kemnaker). It makes **no external network calls** and needs **no
+API keys** — every function returns canned, deterministic data. It exists so the
+rest of the platform can be wired against a realistic interface now and swapped
+for a real connector later.
+
+Two directions, matching the strategy of using the national system as a
+distribution channel + a source of verified supply:
+  • push_vacancies(...)         — feed verified BKK/employer vacancies OUT to the
+                                  national system (returns a canned acknowledgement).
+  • pull_verified_listings(...) — pull verified national listings IN (returns a
+                                  small canned set, each flagged verified + sourced).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Canned national listings. `verified` + `source` let the UI badge them as
+# trusted, government-sourced postings.
+_CANNED_LISTINGS: list[dict[str, Any]] = [
+    {
+        "id": "kh-1001",
+        "title": "Teknisi Jaringan Junior",
+        "company": "PT Solusi Jaringan Nusantara",
+        "region_code": "3171",
+        "salary_min": 4_500_000,
+        "salary_max": 6_000_000,
+        "description": "Instalasi & pemeliharaan jaringan LAN/WAN, troubleshooting perangkat.",
+        "required_skills": ["jaringan komputer", "mikrotik", "troubleshooting"],
+        "verified": True,
+        "source": "karirhub",
+    },
+    {
+        "id": "kh-1002",
+        "title": "Staff Administrasi",
+        "company": "Koperasi Maju Bersama",
+        "region_code": "3578",
+        "salary_min": 4_000_000,
+        "salary_max": 5_000_000,
+        "description": "Pengelolaan dokumen, input data, dukungan operasional kantor.",
+        "required_skills": ["Microsoft Excel", "administrasi", "arsip"],
+        "verified": True,
+        "source": "karirhub",
+    },
+    {
+        "id": "kh-1003",
+        "title": "Operator Produksi",
+        "company": "PT Manufaktur Sejahtera",
+        "region_code": "3273",
+        "salary_min": 4_200_000,
+        "salary_max": 5_500_000,
+        "description": "Mengoperasikan mesin produksi sesuai SOP, quality check dasar.",
+        "required_skills": ["operator mesin", "K3", "ketelitian"],
+        "verified": True,
+        "source": "karirhub",
+    },
+]
+
+
+def push_vacancies(jobs: list[Any]) -> dict[str, Any]:
+    """Pretend to publish vacancies to the national system. Canned acknowledgement.
+
+    No network call is made — this returns a synthetic national-id per job so the
+    UI/flow can be exercised end-to-end.
+    """
+    jobs = list(jobs or [])
+    national_ids = [f"KH-{i:05d}" for i in range(1, len(jobs) + 1)]
+    return {
+        "status": "accepted",
+        "pushed": len(jobs),
+        "national_ids": national_ids,
+        "note": "MOCK Karirhub sync — no external call was made.",
+    }
+
+
+def pull_verified_listings(region: str | None = None) -> list[dict[str, Any]]:
+    """Return canned verified national listings, optionally filtered by region."""
+    if region:
+        return [dict(item) for item in _CANNED_LISTINGS if item["region_code"] == region]
+    return [dict(item) for item in _CANNED_LISTINGS]

--- a/backend/app/services/matching/matcher.py
+++ b/backend/app/services/matching/matcher.py
@@ -11,7 +11,9 @@ Weights are read from settings so they can be tuned via .env without a code chan
 """
 from __future__ import annotations
 
+import hashlib
 import math
+import random
 from collections.abc import Iterable
 
 from backend.app.db.schemas import JobPosting, MatchResult, SeekerProfile
@@ -107,6 +109,39 @@ def _explain(
     sentences.append("**Aksi:** Kirim lamaranmu sekarang sebelum kuota penuh!")
     
     return " ".join(sentences)
+
+
+def _assign_bands(
+    candidates: list[dict],
+    job_id: str,
+    strong_th: float,
+    possible_th: float,
+) -> list[dict]:
+    """Bucket ranked candidates into Strong/Possible/Stretch, then shuffle within
+    each band so tiny score deltas don't imply a false hierarchy.
+
+    The shuffle is seeded by a stable hash of the job id: ordering is stable per
+    job across requests, but unbiased across candidates inside the same band.
+    Embodies the product rule "AI orders attention; the human still decides" —
+    the system groups candidates by fit instead of handing back a finalized
+    top-N ranking.
+    """
+    for c in candidates:
+        s = c["score"]
+        c["band"] = (
+            "strong" if s >= strong_th
+            else "possible" if s >= possible_th
+            else "stretch"
+        )
+    rng = random.Random(int(hashlib.sha256(job_id.encode()).hexdigest()[:8], 16))
+    out: list[dict] = []
+    for band in ("strong", "possible", "stretch"):
+        group = [c for c in candidates if c["band"] == band]
+        rng.shuffle(group)
+        out.extend(group)
+    for i, c in enumerate(out, start=1):
+        c["rank"] = i
+    return out
 
 
 # ── Matcher ───────────────────────────────────────────────────────────────────
@@ -270,6 +305,9 @@ class SemanticMatcher:
                                    if r.lower() not in {sk.name.lower() for sk in s.skills}],
             })
         scored.sort(key=lambda x: x["score"], reverse=True)
-        for i, item in enumerate(scored[:top_k], 1):
-            item["rank"] = i
-        return scored[:top_k]
+        return _assign_bands(
+            scored[:top_k],
+            job.id,
+            settings.band_strong_threshold,
+            settings.band_possible_threshold,
+        )

--- a/backend/scripts/__init__.py
+++ b/backend/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Operational scripts (seed data, benchmarks)."""

--- a/backend/scripts/benchmark_matching.py
+++ b/backend/scripts/benchmark_matching.py
@@ -1,0 +1,227 @@
+"""Exploratory matching benchmark — short, messy SMK-pemula CVs.
+
+⚠️  DIRECTIONAL SIGNAL, NOT PROOF. One synthetic JD + ~100 synthetic CVs. The
+real proof is a recruiter-labelled benchmark. This script exists to probe the
+project's #1 technical risk: does semantic embedding actually beat keyword
+matching on SHORT, MESSY, SPARSE Indonesian vocational CVs whose skills are
+phrased differently from the job description? That lexical-miss case is exactly
+where matching's value is most contestable, so the synthetic CVs are modelled to
+be deliberately sparse and informal.
+
+Headline metric = LIFT = (semantic top-band recall) − (keyword top-band recall)
+on the lexically-varied "good" candidates.
+
+Run:  python -m backend.scripts.benchmark_matching --manual-seconds-per-cv 30
+
+Needs a real GEMINI_API_KEY to be meaningful; without it the embedder is the
+offline HashEmbedder (cosine ≈ 0) and a loud NOT-VALID banner is printed.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import time
+
+from backend.app.db.schemas import (
+    Education,
+    EducationLevel,
+    JobPosting,
+    SeekerProfile,
+    Skill,
+)
+from backend.app.services.matching.embeddings.gemini import HashEmbedder, get_embedder
+from backend.app.services.matching.matcher import SemanticMatcher, _skill_overlap
+
+# Band thresholds mirror backend/app/config/settings.py defaults (scores in 0..1).
+STRONG_TH = 0.65
+POSSIBLE_TH = 0.45
+
+REGIONS = ["3171", "3578", "3273", "3375"]
+
+
+def build_job() -> JobPosting:
+    """A realistic SMK-target vocational entry role; skills phrased *formally*."""
+    return JobPosting(
+        employer_id="bench-emp",
+        title="Teknisi Jaringan Junior",
+        description=(
+            "Dibutuhkan teknisi jaringan pemula untuk instalasi dan pemeliharaan "
+            "jaringan komputer kantor. Tugas: konfigurasi perangkat jaringan, "
+            "pemeliharaan jaringan, dan troubleshooting koneksi."
+        ),
+        required_skills=[
+            "jaringan komputer",
+            "konfigurasi jaringan",
+            "pemeliharaan jaringan",
+            "troubleshooting",
+        ],
+        region_code="3171",
+        education_min=EducationLevel.SMA,
+    )
+
+
+# "good" candidates: genuinely network-capable, but every skill is phrased with
+# concrete/synonym vocabulary that shares ZERO literal tokens with the JD skills.
+GOOD_SKILL_SETS = [
+    ["mikrotik", "setting lan"],
+    ["cisco", "konfigurasi router"],
+    ["wifi", "perbaikan koneksi internet"],
+    ["instalasi kabel utp", "switch"],
+    ["oprek mikrotik", "warnet"],
+    ["routerboard", "winbox"],
+]
+GOOD_HEADLINES = [
+    "lulusan smk tkj, bisa setting jaringan warnet",
+    "anak tkj suka oprek mikrotik sama lan",
+    "smk jaringan, paham cisco basic",
+    "bisa pasang wifi sama benerin koneksi",
+]
+GOOD_RESUMES = [
+    "magang 3 bln di warnet, install mikrotik sama lan",
+    "biasa benerin koneksi kantor, setting router winbox",
+    "",  # some have no resume text at all
+    "pkl di toko komputer, pasang kabel utp",
+]
+
+# distractors: other vocational tracks, unrelated to networking.
+DISTRACTORS = [
+    {"skills": ["memasak", "tata boga"], "headline": "lulusan smk tata boga",
+     "major": "Tata Boga", "resume": "magang di dapur restoran"},
+    {"skills": ["servis motor", "otomotif"], "headline": "smk otomotif bisa servis motor",
+     "major": "TBSM", "resume": "pkl di bengkel motor"},
+    {"skills": ["edit video", "adobe premiere"], "headline": "anak multimedia bisa edit video",
+     "major": "Multimedia", "resume": ""},
+    {"skills": ["pembukuan", "jurnal"], "headline": "lulusan akuntansi smk",
+     "major": "Akuntansi", "resume": "magang input pembukuan"},
+    {"skills": ["desain grafis", "photoshop"], "headline": "bisa desain pakai photoshop",
+     "major": "DKV", "resume": ""},
+    {"skills": ["mengetik cepat", "input data"], "headline": "smk administrasi perkantoran",
+     "major": "OTKP", "resume": "magang arsip kantor"},
+]
+
+
+def _smk(major: str) -> Education:
+    return Education(
+        institution="SMK Negeri Contoh",
+        degree=EducationLevel.SMA,
+        major=major,
+        graduation_year=2024,
+    )
+
+
+def build_seekers(n: int = 100, n_good: int = 20) -> list[tuple[SeekerProfile, bool]]:
+    out: list[tuple[SeekerProfile, bool]] = []
+    for i in range(n):
+        is_good = i < n_good
+        if is_good:
+            skills = GOOD_SKILL_SETS[i % len(GOOD_SKILL_SETS)]
+            headline = GOOD_HEADLINES[i % len(GOOD_HEADLINES)]
+            resume = GOOD_RESUMES[i % len(GOOD_RESUMES)]
+            major = "Teknik Komputer dan Jaringan"
+        else:
+            d = DISTRACTORS[i % len(DISTRACTORS)]
+            skills, headline, resume, major = d["skills"], d["headline"], d["resume"], d["major"]
+        seeker = SeekerProfile(
+            user_id=f"bench-u-{i:03d}",
+            full_name=f"Kandidat {i:03d}",
+            headline=headline,
+            region_code=REGIONS[i % len(REGIONS)],
+            skills=[Skill(name=s) for s in skills],
+            education=[_smk(major)],
+            resume_text=resume,
+            salary_expectation_min=4_000_000,
+            salary_expectation_max=5_500_000,
+        )
+        out.append((seeker, is_good))
+    return out
+
+
+def _band(score: float) -> str:
+    return "strong" if score >= STRONG_TH else "possible" if score >= POSSIBLE_TH else "stretch"
+
+
+def _recall_in_strong(score_by_id: dict[str, float], good_ids: set[str]) -> float:
+    if not good_ids:
+        return 0.0
+    hits = sum(1 for gid in good_ids if _band(score_by_id.get(gid, 0.0)) == "strong")
+    return hits / len(good_ids)
+
+
+async def run(manual_seconds_per_cv: float) -> None:
+    job = build_job()
+    labeled = build_seekers()
+    seekers = [s for s, _ in labeled]
+    good_ids = {s.id for s, g in labeled if g}
+
+    embedder = get_embedder()
+    using_hash = isinstance(embedder, HashEmbedder)
+
+    matcher = SemanticMatcher()
+    await matcher.embed_job(job)
+    for s in seekers:
+        await matcher.embed_seeker(s)
+
+    t0 = time.perf_counter()
+    ranked = await matcher.rank_seekers_for_job(job, seekers, top_k=len(seekers))
+    ai_seconds = time.perf_counter() - t0
+
+    sem_score = {r["seeker_id"]: float(r["score"]) for r in ranked}
+    kw_score = {
+        s.id: _skill_overlap([sk.name for sk in s.skills], job.required_skills)
+        for s in seekers
+    }
+
+    sem_recall = _recall_in_strong(sem_score, good_ids)
+    kw_recall = _recall_in_strong(kw_score, good_ids)
+    lift = sem_recall - kw_recall
+
+    n = len(seekers)
+    manual_seconds = n * manual_seconds_per_cv
+    reduction = (1 - ai_seconds / manual_seconds) if manual_seconds else 0.0
+
+    print("=" * 72)
+    print("KerjaCerdas - matching benchmark (EXPLORATORY / DIRECTIONAL, NOT PROOF)")
+    print("Case: short, messy SMK-pemula CVs; good candidates use skill vocab")
+    print("      that shares zero literal tokens with the JD (lexical-miss case).")
+    print("=" * 72)
+    if using_hash:
+        print()
+        print("!!! RESULTS NOT VALID FOR LIFT: ran on HashEmbedder (cosine ~ 0).   !!!")
+        print("!!! Set GEMINI_API_KEY to measure real embedding lift.             !!!")
+        print()
+    print(f"embedder           : {type(embedder).__name__} (model={getattr(embedder, 'model', '?')})")
+    print(f"candidates         : {n}  (good={len(good_ids)}, distractors={n - len(good_ids)})")
+    print(f"JD required_skills : {job.required_skills}")
+    print("-" * 72)
+    print("HEADLINE - top-band (Strong) recall of the lexically-varied good CVs:")
+    print(f"  keyword-only baseline : {kw_recall:6.1%}")
+    print(f"  semantic (hybrid)     : {sem_recall:6.1%}")
+    print(f"  >>> LIFT (sem - kw)   : {lift:+6.1%}")
+    print("-" * 72)
+    print(f"time-to-shortlist (AI rank of {n} CVs): {ai_seconds * 1000:.0f} ms")
+    print(f"illustrative manual baseline @ {manual_seconds_per_cv:.0f}s/CV: {manual_seconds:.0f}s")
+    print(f"  (ASSUMPTION, not a measured human time) -> reduction ~ {reduction:.0%}")
+    print("=" * 72)
+    print("Interpretation: positive lift on this messy text = the semantic step")
+    print("adds real value where keyword matching fails. ~0 lift = the risk has")
+    print("bitten (or you're on HashEmbedder). Use this score distribution to")
+    print("calibrate band thresholds in settings.py before trusting the bands.")
+    print("=" * 72)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="KerjaCerdas matching benchmark (exploratory / directional)."
+    )
+    parser.add_argument(
+        "--manual-seconds-per-cv",
+        type=float,
+        default=30.0,
+        help="Illustrative manual screening time per CV (an assumption, not measured).",
+    )
+    args = parser.parse_args()
+    asyncio.run(run(args.manual_seconds_per_cv))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_jobs_verified.py
+++ b/backend/tests/unit/test_jobs_verified.py
@@ -1,0 +1,27 @@
+"""Unit 4 — verified-listing trust flag (pure helper, DB-free)."""
+from __future__ import annotations
+
+from backend.app.api.routers.jobs import _is_verified
+from backend.app.db.schemas import Employer, VerificationStatus
+
+
+def _employer(status: VerificationStatus) -> Employer:
+    return Employer(
+        user_id="u-1",
+        company_name="PT Contoh",
+        region_code="3171",
+        verified=status,
+    )
+
+
+def test_verified_employer_is_trusted() -> None:
+    assert _is_verified(_employer(VerificationStatus.VERIFIED)) is True
+
+
+def test_unverified_employer_is_not_trusted() -> None:
+    assert _is_verified(_employer(VerificationStatus.UNVERIFIED)) is False
+    assert _is_verified(_employer(VerificationStatus.PENDING)) is False
+
+
+def test_missing_employer_is_not_trusted() -> None:
+    assert _is_verified(None) is False

--- a/backend/tests/unit/test_karirhub.py
+++ b/backend/tests/unit/test_karirhub.py
@@ -1,0 +1,53 @@
+"""Unit 3 — MOCK Karirhub connector + router.
+
+Imports only the lightweight karirhub router (not the full app) so the suite
+runs without the heavy AI stack or a live database.
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.app.api.routers.karirhub import router
+from backend.app.services.integrations import karirhub
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    return TestClient(app)
+
+
+def test_pull_verified_listings_are_flagged() -> None:
+    items = karirhub.pull_verified_listings()
+    assert items
+    assert all(i["verified"] is True and i["source"] == "karirhub" for i in items)
+
+
+def test_pull_verified_listings_region_filter() -> None:
+    all_items = karirhub.pull_verified_listings()
+    region = all_items[0]["region_code"]
+    filtered = karirhub.pull_verified_listings(region=region)
+    assert filtered
+    assert all(i["region_code"] == region for i in filtered)
+
+
+def test_push_vacancies_ack() -> None:
+    ack = karirhub.push_vacancies([{"id": "a"}, {"id": "b"}])
+    assert ack["status"] == "accepted"
+    assert ack["pushed"] == 2
+    assert len(ack["national_ids"]) == 2
+
+
+def test_listings_endpoint() -> None:
+    res = _client().get("/api/v1/karirhub/listings")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] >= 1
+    assert all(i["verified"] is True and i["source"] == "karirhub" for i in body["items"])
+
+
+def test_sync_endpoint() -> None:
+    res = _client().post("/api/v1/karirhub/sync", json={})
+    assert res.status_code == 200
+    assert res.json()["status"] == "accepted"

--- a/backend/tests/unit/test_matching_bands.py
+++ b/backend/tests/unit/test_matching_bands.py
@@ -1,0 +1,85 @@
+"""Unit 1 — employer-side match bands + within-band randomization.
+
+Verifies that the recruiter shortlist is grouped into Strong/Possible/Stretch
+instead of a finalized ranking, and that ordering inside a band is stable per
+job but does not leak a false hierarchy.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.app.config.settings import settings
+from backend.app.db.schemas import JobPosting, SeekerProfile, Skill
+from backend.app.services.matching.matcher import SemanticMatcher, _assign_bands
+
+
+def _seeker(name: str, skills: list[str]) -> SeekerProfile:
+    return SeekerProfile(
+        user_id=f"u-{name}",
+        full_name=name,
+        region_code="3171",
+        skills=[Skill(name=s) for s in skills],
+    )
+
+
+def test_assign_bands_buckets_by_threshold_and_orders() -> None:
+    cands = [
+        {"seeker_id": "a", "score": 0.90},
+        {"seeker_id": "b", "score": 0.50},
+        {"seeker_id": "c", "score": 0.10},
+        {"seeker_id": "d", "score": 0.66},
+    ]
+    out = _assign_bands(cands, "job-xyz", 0.65, 0.45)
+
+    bands = {c["seeker_id"]: c["band"] for c in out}
+    assert bands == {"a": "strong", "d": "strong", "b": "possible", "c": "stretch"}
+    # emitted strong -> possible -> stretch, with a contiguous 1..N rank
+    assert [c["band"] for c in out] == ["strong", "strong", "possible", "stretch"]
+    assert [c["rank"] for c in out] == [1, 2, 3, 4]
+
+
+def test_assign_bands_shuffle_is_stable_per_job() -> None:
+    def fresh() -> list[dict]:
+        return [{"seeker_id": str(i), "score": 0.90} for i in range(8)]
+
+    first = [c["seeker_id"] for c in _assign_bands(fresh(), "job-1", 0.65, 0.45)]
+    again = [c["seeker_id"] for c in _assign_bands(fresh(), "job-1", 0.65, 0.45)]
+    other = [c["seeker_id"] for c in _assign_bands(fresh(), "job-2", 0.65, 0.45)]
+
+    assert first == again, "ordering must be stable for the same job id"
+    # different seed -> (almost surely) a different in-band order
+    assert other != first or len(set(first)) <= 1
+
+
+@pytest.mark.asyncio
+async def test_rank_seekers_includes_band_and_rank() -> None:
+    job = JobPosting(
+        employer_id="emp-1",
+        title="Junior Data Analyst",
+        description="Analisis data dengan Excel dan SQL.",
+        required_skills=["Excel", "SQL", "Python"],
+        region_code="3171",
+    )
+    seekers = [
+        _seeker("Full", ["Excel", "SQL", "Python"]),
+        _seeker("One", ["Excel"]),
+        _seeker("None", ["Memasak"]),
+    ]
+
+    ranked = await SemanticMatcher().rank_seekers_for_job(job, seekers, top_k=15)
+
+    assert ranked, "expected ranked candidates"
+    assert all(c.get("band") in {"strong", "possible", "stretch"} for c in ranked)
+    assert [c["rank"] for c in ranked] == list(range(1, len(ranked) + 1))
+    # bands are emitted in strong -> possible -> stretch order
+    order = {"strong": 0, "possible": 1, "stretch": 2}
+    seq = [order[c["band"]] for c in ranked]
+    assert seq == sorted(seq)
+    # and each band is consistent with the configured thresholds
+    for c in ranked:
+        if c["band"] == "strong":
+            assert c["score"] >= settings.band_strong_threshold
+        elif c["band"] == "possible":
+            assert settings.band_possible_threshold <= c["score"] < settings.band_strong_threshold
+        else:
+            assert c["score"] < settings.band_possible_threshold

--- a/frontend/src/components/EmployerCandidates.jsx
+++ b/frontend/src/components/EmployerCandidates.jsx
@@ -7,12 +7,21 @@ import useStore from '../store/useStore'
 import { fetchCandidatesForJob } from '../services/api'
 import { KC, BrutalCard, RankSticker, ScoreDonut, Tag, BrutalChip } from './_design'
 
+const BANDS = [
+    { key: 'strong', label: 'Strong fit', color: KC.lime },
+    { key: 'possible', label: 'Possible fit', color: KC.yellow },
+    { key: 'stretch', label: 'Stretch', color: KC.cyan },
+]
+// Use the server-assigned band; fall back to thresholds on the 0–100 score
+// (mirrors the backend's 0.65 / 0.45 cutoffs) so this view works standalone.
+const bandOf = (c) => c.band || (c.score >= 65 ? 'strong' : c.score >= 45 ? 'possible' : 'stretch')
+
 const DEMO_CANDIDATES = [
-    { name: 'Rina Pertiwi', verified: true, score: 94, title: 'Senior Backend Engineer · 6 thn exp', location: 'Jakarta', exp: '6 thn', edu: 'S1 ITB', prev: 'Bukalapak', skills: ['Go', 'PostgreSQL', 'gRPC', 'Kafka', 'K8s'], gap: [], ai: 'Stack 100% overlap. Pernah handle 100K RPS di Bukalapak payment.' },
-    { name: 'Andika Pratama', verified: true, score: 91, title: 'Backend Lead · 7 thn exp', location: 'Jakarta', exp: '7 thn', edu: 'S1 UI', prev: 'Bibit', skills: ['Go', 'PostgreSQL', 'Redis', 'gRPC'], gap: ['Kafka'], ai: 'Leadership kuat, gap Kafka ditutup 2 minggu.' },
-    { name: 'Sari Ningrum', verified: true, score: 87, title: 'Staff Backend · 8 thn exp', location: 'Bandung', exp: '8 thn', edu: 'S1 ITB', prev: 'GoTo', skills: ['Go', 'Microservices', 'K8s'], gap: ['gRPC'], ai: 'Microservices depth tinggi.' },
-    { name: 'Bayu Wicaksono', verified: true, score: 83, title: 'Senior SWE · 5 thn exp', location: 'Jakarta', exp: '5 thn', edu: 'S1 UGM', prev: 'Tokopedia', skills: ['Go', 'PostgreSQL', 'gRPC'], gap: ['Kafka', 'K8s'], ai: 'Stack fit, willing remote.' },
-    { name: 'Mira Anggraini', verified: false, score: 80, title: 'Backend Engineer · 4 thn exp', location: 'Jakarta', exp: '4 thn', edu: 'S1 ITS', prev: 'Xendit', skills: ['Node', 'TypeScript', 'PostgreSQL'], gap: ['Go', 'gRPC'], ai: 'Belum verifikasi KTP, kandidat under-rated.' },
+    { name: 'Rina Pertiwi', band: 'strong', verified: true, score: 94, title: 'Senior Backend Engineer · 6 thn exp', location: 'Jakarta', exp: '6 thn', edu: 'S1 ITB', prev: 'Bukalapak', skills: ['Go', 'PostgreSQL', 'gRPC', 'Kafka', 'K8s'], gap: [], ai: 'Stack 100% overlap. Pernah handle 100K RPS di Bukalapak payment.' },
+    { name: 'Andika Pratama', band: 'strong', verified: true, score: 91, title: 'Backend Lead · 7 thn exp', location: 'Jakarta', exp: '7 thn', edu: 'S1 UI', prev: 'Bibit', skills: ['Go', 'PostgreSQL', 'Redis', 'gRPC'], gap: ['Kafka'], ai: 'Leadership kuat, gap Kafka ditutup 2 minggu.' },
+    { name: 'Sari Ningrum', band: 'possible', verified: true, score: 87, title: 'Staff Backend · 8 thn exp', location: 'Bandung', exp: '8 thn', edu: 'S1 ITB', prev: 'GoTo', skills: ['Go', 'Microservices', 'K8s'], gap: ['gRPC'], ai: 'Microservices depth tinggi.' },
+    { name: 'Bayu Wicaksono', band: 'possible', verified: true, score: 83, title: 'Senior SWE · 5 thn exp', location: 'Jakarta', exp: '5 thn', edu: 'S1 UGM', prev: 'Tokopedia', skills: ['Go', 'PostgreSQL', 'gRPC'], gap: ['Kafka', 'K8s'], ai: 'Stack fit, willing remote.' },
+    { name: 'Mira Anggraini', band: 'stretch', verified: false, score: 80, title: 'Backend Engineer · 4 thn exp', location: 'Jakarta', exp: '4 thn', edu: 'S1 ITS', prev: 'Xendit', skills: ['Node', 'TypeScript', 'PostgreSQL'], gap: ['Go', 'gRPC'], ai: 'Belum verifikasi KTP, kandidat under-rated.' },
 ]
 
 export default function EmployerCandidates() {
@@ -32,12 +41,13 @@ export default function EmployerCandidates() {
         ;(async () => {
             setLoading(true)
             try {
-                const data = await fetchCandidatesForJob(selectedJobId, 5)
+                const data = await fetchCandidatesForJob(selectedJobId, 15)
                 if (!alive) return
                 if (data.candidates?.length) {
                     setCandidates(data.candidates.map(c => ({
                         name: c.full_name || 'Kandidat',
                         verified: c.verified ?? false,
+                        band: c.band,
                         score: Math.round((c.score ?? c.overall_score ?? 0) > 1 ? (c.score ?? c.overall_score ?? 0) : (c.score ?? c.overall_score ?? 0) * 100),
                         title: c.headline || '—',
                         location: c.region_code || 'Jakarta',
@@ -66,9 +76,9 @@ export default function EmployerCandidates() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
             <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingBottom: 20, borderBottom: `2px solid ${KC.ink}` }}>
                 <div>
-                    <h1 style={{ fontSize: 30, fontWeight: 900, letterSpacing: -1, margin: 0 }}>Top 5 Kandidat</h1>
+                    <h1 style={{ fontSize: 30, fontWeight: 900, letterSpacing: -1, margin: 0 }}>Kandidat</h1>
                     <p style={{ fontSize: 14, color: KC.mute, margin: '4px 0 0' }}>
-                        Untuk: {jobTitle} · {totalApplicants} lamaran di-rank oleh Gemini
+                        Untuk: {jobTitle} · {totalApplicants} lamaran · diurutkan AI ke dalam band · keputusan tetap di tangan Anda
                         {usedDemo && <Tag color={KC.yellow} size="sm" style={{ marginLeft: 8 }}>DEMO</Tag>}
                     </p>
                 </div>
@@ -94,21 +104,36 @@ export default function EmployerCandidates() {
                 <p style={{ fontFamily: 'JetBrains Mono, monospace', color: KC.orange, fontWeight: 700 }}>Gemini reranking kandidat…</p>
             </BrutalCard>}
 
-            {!loading && (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 16, marginTop: 8 }}>
-                    {filtered.map((c, i) => <CandidateCard key={i} candidate={c} rank={i + 1} />)}
-                </div>
-            )}
+            {!loading && (() => {
+                let r = 0
+                const groups = BANDS
+                    .map(b => ({ ...b, items: filtered.filter(c => bandOf(c) === b.key) }))
+                    .filter(g => g.items.length)
+                return (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 24, marginTop: 8 }}>
+                        {groups.map(g => (
+                            <div key={g.key} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                                    <span style={{ width: 14, height: 14, background: g.color, border: `2px solid ${KC.ink}`, borderRadius: 4, boxShadow: `1.5px 1.5px 0 ${KC.ink}` }} />
+                                    <h2 style={{ fontSize: 17, fontWeight: 900, letterSpacing: -0.4, margin: 0 }}>{g.label}</h2>
+                                    <Tag color={g.color} size="sm">{g.items.length}</Tag>
+                                </div>
+                                {g.items.map(c => { r += 1; return <CandidateCard key={r} candidate={c} rank={r} band={g.key} bandColor={g.color} /> })}
+                            </div>
+                        ))}
+                    </div>
+                )
+            })()}
 
             <div style={{ marginTop: 12, padding: 14, background: '#fff', border: `2px dashed ${KC.ink}`, borderRadius: 12, textAlign: 'center', fontSize: 13, fontWeight: 700, color: KC.mute }}>
-                Plan Growth: top-10. Sisanya 79 kandidat dengan score &lt; 80. <span style={{ color: KC.ink, textDecoration: 'underline', cursor: 'pointer' }}>Upgrade ke Scale</span> buat top-50.
+                Band dihitung dari kecocokan semantik + skill. Kandidat diacak dalam tiap band untuk mengurangi bias urutan — AI mengurutkan perhatian, keputusan tetap di tangan Anda.
             </div>
         </div>
     )
 }
 
-function CandidateCard({ candidate: c, rank }) {
-    const [unlocked, setUnlocked] = React.useState(false)
+function CandidateCard({ candidate: c, rank, band, bandColor }) {
+    const [unlocked, setUnlocked] = useState(false)
     const accent = c.score >= 90 ? KC.orange : c.score >= 85 ? KC.yellow : c.score >= 80 ? KC.cyan : KC.lime
     const avatarColors = [KC.cyan, KC.yellow, KC.lime, KC.pink, KC.orange]
     const aColor = avatarColors[(rank - 1) % avatarColors.length]
@@ -125,6 +150,7 @@ function CandidateCard({ candidate: c, rank }) {
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
                         <h3 style={{ fontSize: 18, fontWeight: 900, letterSpacing: -0.4, lineHeight: 1.2, margin: 0 }}>{c.name}</h3>
                         {c.verified && <Tag color={KC.lime} size="sm">✓ VERIFIED</Tag>}
+                        {band && <Tag color={bandColor || KC.cyan} size="sm">{String(band).toUpperCase()}</Tag>}
                         <div style={{ marginLeft: 'auto' }}><ScoreDonut value={c.score} size={42} color={accent} label="" /></div>
                     </div>
                     <div style={{ fontSize: 13, fontWeight: 700, color: KC.mute, marginBottom: 8 }}>{c.title}</div>

--- a/frontend/src/components/JobDetailModal.jsx
+++ b/frontend/src/components/JobDetailModal.jsx
@@ -47,8 +47,9 @@ export default function JobDetailModal({ job, onClose }) {
                     display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between',
                 }}>
                     <div>
-                        <div style={{ fontSize: 13, fontWeight: 800, opacity: 0.75, marginBottom: 4 }}>
+                        <div style={{ fontSize: 13, fontWeight: 800, opacity: 0.75, marginBottom: 4, display: 'flex', alignItems: 'center', gap: 8 }}>
                             {job.company || 'Perusahaan'}
+                            {job.verified && <Tag color={KC.lime} size="sm">✓ Terverifikasi</Tag>}
                         </div>
                         <h2 style={{ fontSize: 26, fontWeight: 900, letterSpacing: -0.8, margin: 0, lineHeight: 1.15 }}>
                             {job.title || 'Posisi'}

--- a/frontend/src/components/SeekerMatchResults.jsx
+++ b/frontend/src/components/SeekerMatchResults.jsx
@@ -183,7 +183,8 @@ function MatchCard({ rank, match, saved, onSave, onView }) {
                 <div style={{ minWidth: 0 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
                         <div style={{ width: 28, height: 28, background: KC.cyan, border: `1.5px solid ${KC.ink}`, borderRadius: 6, display: 'grid', placeItems: 'center', fontWeight: 900, fontSize: 12 }}>{company[0]}</div>
-                        <div style={{ fontSize: 13, fontWeight: 700, color: KC.mute }}>{company} ✓</div>
+                        <div style={{ fontSize: 13, fontWeight: 700, color: KC.mute }}>{company}</div>
+                        {match.verified && <Tag color={KC.lime} size="sm">✓ Terverifikasi</Tag>}
                     </div>
                     <h3 style={{ fontSize: 20, fontWeight: 900, letterSpacing: -0.6, lineHeight: 1.15, margin: 0 }}>
                         {match.title || match.job_title || 'Posisi'}

--- a/frontend/src/components/SeekerSearch.jsx
+++ b/frontend/src/components/SeekerSearch.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { searchJobs } from '../services/api'
 import useStore from '../store/useStore'
-import { BrutalCard, KC, topBtn, DesignStyles } from './_design'
+import { BrutalCard, KC, topBtn, Tag, DesignStyles } from './_design'
 
 export default function SeekerSearch() {
     const [query, setQuery] = useState('')
@@ -67,6 +67,7 @@ export default function SeekerSearch() {
                                     <div>
                                         <h3 style={{ margin: 0, fontSize: 18, fontWeight: 900 }}>{job.title}</h3>
                                         <p style={{ margin: '4px 0', fontSize: 14, color: KC.mute }}>{job.location} • {job.job_type}</p>
+                                        {job.verified && <div style={{ marginTop: 4 }}><Tag color={KC.lime} size="sm">✓ Terverifikasi</Tag></div>}
                                     </div>
                                     {aiScore !== null ? (
                                         <div style={{ background: KC.lime, border: `2px solid ${KC.ink}`, padding: '4px 8px', fontWeight: 900, fontSize: 12, boxShadow: `2px 2px 0 ${KC.ink}` }}>


### PR DESCRIPTION
## What & why
Implements the approved minimal-alignment plan — aligning matching with **"AI orders attention; humans decide"** and adding two mocked partner integrations, without big changes. Scope locked with the user: employer-side bands only; mock Karirhub + verified badge; benchmark on synthetic SMK-pemula CVs.

## Changes
- **Match bands (employer shortlist)** — `rank_seekers_for_job` groups candidates into **Strong / Possible / Stretch** with within-band randomization (seeded by job id → stable per job, unbiased within band); tunable thresholds in `settings.py`. `EmployerCandidates.jsx` renders the three bands instead of a ranked "Top 5".
- **Karirhub connector (MOCK)** — `push_vacancies` / `pull_verified_listings` (canned, no network/keys) at `POST /api/v1/karirhub/sync` and `GET /api/v1/karirhub/listings`.
- **Verified-listing badge** — jobs API attaches a derived `verified` flag from employer verification status; "✓ Terverifikasi" on seeker job cards.
- **Exploratory benchmark** — `backend/scripts/benchmark_matching.py` over ~100 short/messy SMK-pemula CVs whose good candidates phrase skills differently from the JD; headline metric is **semantic-vs-keyword lift**, with a loud HashEmbedder validity guard. Directional, not proof.

## Verification
- 11 new unit tests pass (`test_matching_bands`, `test_karirhub`, `test_jobs_verified`).
- `npm run build` passes.
- Benchmark runs; prints the NOT-VALID-FOR-LIFT banner without a key (run with `GEMINI_API_KEY` for a real lift number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)